### PR TITLE
fix indent and tags regex in workflow file

### DIFF
--- a/.github/workflows/docker_image_build.yaml
+++ b/.github/workflows/docker_image_build.yaml
@@ -5,7 +5,8 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+\+[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)*([\+.][0-9]+)*'
+      - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+'
 
 jobs:
   docker:
@@ -46,7 +47,7 @@ jobs:
             latest=false
             prefix=
             suffix=
-       -
+      -
         name: Build and push standard image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
There was an indentation issue.
The last regex is too complex.
You have to split it in independent ones. This is what I did assuming you want to support the following tags:
* 1.2.3
* 1.2.3+12
* 1.2.3.34
* 1.2.3-beta1