### PR TITLE
Fix an error when a call timeout is provided by the client (AB|JS and…

### DIFF
--- a/apps/bondy/src/bondy_utils.erl
+++ b/apps/bondy/src/bondy_utils.erl
@@ -301,10 +301,7 @@ external_session_id(undefined) ->
 %% @end
 %% -----------------------------------------------------------------------------
 timeout(#{timeout := T}) when is_integer(T), T > 0 ->
-    case T >= 1000 of
-        true -> T;  %% it assumes are ms
-        false -> T * 1000 %% it assumes are seconds
-    end;
+    T;
 timeout(#{timeout := 0}) ->
     bondy_config:get(wamp_max_call_timeout);
 timeout(_) ->

--- a/apps/bondy/src/bondy_utils.erl
+++ b/apps/bondy/src/bondy_utils.erl
@@ -294,13 +294,19 @@ external_session_id(undefined) ->
     undefined.
 
 %% -----------------------------------------------------------------------------
-%% @doc
+%% @doc It returns the timeout in ms.
+%% - Provided timeout if it is greater than 0
+%% - wamp_max_call_timeout if the provided timeout is equals to 0
+%% - wamp_call_timeout if no timeout is provided
 %% @end
 %% -----------------------------------------------------------------------------
 timeout(#{timeout := T}) when is_integer(T), T > 0 ->
-    T;
+    case T >= 1000 of
+        true -> T;  %% it assumes are ms
+        false -> T * 1000 %% it assumes are seconds
+    end;
 timeout(#{timeout := 0}) ->
-    infinity;
+    bondy_config:get(wamp_max_call_timeout);
 timeout(_) ->
     bondy_config:get(wamp_call_timeout).
 


### PR DESCRIPTION
Fix an error when a call timeout is provided by the client (AB|JS and AB|Python works with timeout option in seconds).
The error is raised in **tuplespace_queue** module in function `future_time` produced by the module **bondy_rpc_promise** in function `enqueue` that assumes the received timeout is in milliseconds to transform it in seconds.
The change is in bondy_utils:timeout to detect this situation and always returns timeout expressed in ms.

Maybe to check the behavior in **tuplespace_queue** module regarding to the infinity usages
