### PR TITLE
Include x_authroles in authextra dictionary

### DIFF
--- a/apps/bondy/src/bondy_session.erl
+++ b/apps/bondy/src/bondy_session.erl
@@ -86,6 +86,9 @@
                                         authrole => binary(),
                                         authmethod => binary(),
                                         authprovider => binary(),
+                                        authextra => #{
+                                            x_authroles => [binary()]
+                                        },
                                         transport => #{
                                             agent => binary(),
                                             peername => binary()
@@ -794,7 +797,7 @@ to_external(#session{} = S) ->
         authmethod => S#session.authmethod,
         authprovider => <<"com.leapsight.bondy">>,
         authextra => #{
-            'x_authroles' => S#session.authroles
+            x_authroles => S#session.authroles
         },
         transport => #{
             agent => S#session.agent,

--- a/apps/bondy/src/bondy_session.erl
+++ b/apps/bondy/src/bondy_session.erl
@@ -793,6 +793,9 @@ to_external(#session{} = S) ->
         'x_authroles' => S#session.authroles,
         authmethod => S#session.authmethod,
         authprovider => <<"com.leapsight.bondy">>,
+        authextra => #{
+            'x_authroles' => S#session.authroles
+        },
         transport => #{
             agent => S#session.agent,
             peername => inet_utils:peername_to_binary(S#session.peer)


### PR DESCRIPTION
This may just work and the clients using that feature will stay conformant and it doesn't break backwards compatibility.

Lets see if the CI likes it