### PR TITLE
Minor fixes parsing features in the client roles

### DIFF
--- a/apps/bondy/src/bondy.erl
+++ b/apps/bondy/src/bondy.erl
@@ -335,6 +335,9 @@ set_process_metadata(Meta0, LogKeys0) when is_map(Meta0), is_list(LogKeys0) ->
     _ = put(?BONDY_META_KEY, Bondy),
     ok = logger:set_process_metadata(Logger);
 
+set_process_metadata(undefined, _LogKeys) ->
+    ok;
+
 set_process_metadata(Meta, LogKeys) ->
     erlang:error(badarg, [Meta, LogKeys]).
 

--- a/apps/bondy/src/bondy_session.erl
+++ b/apps/bondy/src/bondy_session.erl
@@ -950,9 +950,13 @@ parse_properties(_, _, Session) ->
 %% ------------------------------------------------------------------------
 parse_roles(Roles) ->
     maps:map(
-        fun(Key, #{features := Requested}) ->
-            Merged = merge_feature_flags(Key, Requested),
-            #{features => Merged}
+        fun
+            (Key, #{features := Requested}) ->
+                Merged = merge_feature_flags(Key, Requested),
+                #{features => Merged};
+            (Key, #{}) ->
+                Merged = merge_feature_flags(Key, #{}),
+                #{features => Merged}
         end,
         Roles
     ).


### PR DESCRIPTION
- Minor change in `bondy.set_process_metadata` function to handle the undefined metadata received in http gateway requests

- Minor change in `bondy_session.parse_roles` to be able to handle when features for the role are not provided (example for callee role using jawampa client)